### PR TITLE
Add tag for wheel events

### DIFF
--- a/src/DOM/HTML/Indexed.purs
+++ b/src/DOM/HTML/Indexed.purs
@@ -1,7 +1,7 @@
 module DOM.HTML.Indexed where
 
 import DOM.Event.ClipboardEvent (ClipboardEvent)
-import DOM.Event.Types (Event, MouseEvent, KeyboardEvent, FocusEvent, TouchEvent)
+import DOM.Event.Types (Event, FocusEvent, KeyboardEvent, MouseEvent, TouchEvent, WheelEvent)
 import DOM.HTML.Event.Types (DragEvent)
 import DOM.HTML.Indexed.ButtonType (ButtonType)
 import DOM.HTML.Indexed.CrossOriginValue (CrossOriginValue)
@@ -119,7 +119,7 @@ type ClipboardEvents r =
   | r
   )
 
-type InteractiveEvents r = ClipboardEvents (FocusEvents (TransitionEvents (KeyEvents (PointerEvents (TouchEvents (DragEvents (MouseEvents r)))))))
+type InteractiveEvents r = ClipboardEvents (FocusEvents (TransitionEvents (KeyEvents (PointerEvents (TouchEvents (DragEvents (MouseEvents (onWheel :: WheelEvent | r))))))))
 
 type GlobalProperties r = GlobalAttributes (GlobalEvents r)
 


### PR DESCRIPTION
Adds a tag to interactive events to support `onWheel`. PR slamdata/purescript-halogen#474 is the other half of this.

Seems simple and works for my use-case (zooming an SVG), but not tested to any great depth.